### PR TITLE
Allow MIQ PG config overrides to be included

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM centos/postgresql-95-centos7
 
 MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 
+# Include config PG dir
+ARG PG_CONF_DIR=/var/lib/pgsql/conf.d
+
 # Switch USER to root to add required repo and packages
 USER root
 
@@ -22,7 +25,8 @@ LABEL io.openshift.tags="database,postgresql,postgresql95,rh-postgresql95,pglogi
 COPY docker-assets/run-postgresql /usr/bin
 
 # Loosen permission bits to avoid problems running container with arbitrary UID
-RUN /usr/libexec/fix-permissions /var/lib/pgsql && \
+RUN mkdir ${PG_CONF_DIR} && \
+    /usr/libexec/fix-permissions /var/lib/pgsql && \
     /usr/libexec/fix-permissions /var/run/postgresql
 
 # Switch USER back to postgres

--- a/docker-assets/run-postgresql
+++ b/docker-assets/run-postgresql
@@ -14,14 +14,19 @@ function set_miq_role() {
 
 # Include MIQ config overrides if directory present
 function include_miq_config() {
-  POSTGRESQL_CONFIG_DIR=${POSTGRESQL_CONFIG_DIR:-/etc/manageiq/postgresql.conf.d}
-  if [ -d "${POSTGRESQL_CONFIG_DIR}" ]; then
+  # Set and create default dir if POSTGRESQL_CONFIG_DIR is not defined, compatible with older builds
+  POSTGRESQL_CONFIG_DIR=${POSTGRESQL_CONFIG_DIR:-/var/lib/pgsql/conf.d}
+
+  # Check for POSTGRESQL_CONFIG_DIR presence in postgresql.conf, if already there skip.
+  [[ $(grep ${POSTGRESQL_CONFIG_DIR} ${PGDATA}/postgresql.conf) ]] && RET=$? || RET=$?
+  if [[ $RET == "0" ]]; then
+    echo "${POSTGRESQL_CONFIG_DIR} already exists on ${PGDATA}/postgresql.conf, skipping.."
+  else
+   echo "Writing ${POSTGRESQL_CONFIG_DIR} config directory to ${PGDATA}/postgresql.conf"
     cat >> "$PGDATA/postgresql.conf" <<EOF
 # Begin ManageIQ configuration overrides:
 include_dir '${POSTGRESQL_CONFIG_DIR}'
 EOF
-  else
-    echo "${POSTGRESQL_CONFIG_DIR} directory not found, skipping config overrides.."
   fi
 }
 
@@ -35,13 +40,15 @@ if [ ! -f "$PGDATA/postgresql.conf" ]; then
   NEED_TO_CREATE_USERS=yes
 fi
 
+# Include MIQ overrides before first-startup
+include_miq_config
+
 pg_ctl -w start -o "-h ''"
 if [ "${NEED_TO_CREATE_USERS:-}" == "yes" ]; then
   create_users
 fi
 set_passwords
 set_miq_role
-include_miq_config
 pg_ctl stop
 
 unset_env_vars

--- a/docker-assets/run-postgresql
+++ b/docker-assets/run-postgresql
@@ -18,8 +18,7 @@ function include_miq_config() {
   POSTGRESQL_CONFIG_DIR=${POSTGRESQL_CONFIG_DIR:-/var/lib/pgsql/conf.d}
 
   # Check for POSTGRESQL_CONFIG_DIR presence in postgresql.conf, if already there skip.
-  [[ $(grep ${POSTGRESQL_CONFIG_DIR} ${PGDATA}/postgresql.conf) ]] && RET=$? || RET=$?
-  if [[ $RET == "0" ]]; then
+  if [[ $(grep ${POSTGRESQL_CONFIG_DIR} ${PGDATA}/postgresql.conf) && $? -eq 0 ]]; then
     echo "${POSTGRESQL_CONFIG_DIR} already exists on ${PGDATA}/postgresql.conf, skipping.."
   else
    echo "Writing ${POSTGRESQL_CONFIG_DIR} config directory to ${PGDATA}/postgresql.conf"

--- a/docker-assets/run-postgresql
+++ b/docker-assets/run-postgresql
@@ -12,6 +12,19 @@ function set_miq_role() {
   psql --command "ALTER ROLE \"${POSTGRESQL_USER}\" SUPERUSER LOGIN PASSWORD '${POSTGRESQL_PASSWORD}';"
 }
 
+# Include MIQ config overrides if directory present
+function include_miq_config() {
+  POSTGRESQL_CONFIG_DIR=${POSTGRESQL_CONFIG_DIR:-/etc/manageiq/postgresql.conf.d}
+  if [ -d "${POSTGRESQL_CONFIG_DIR}" ]; then
+    cat >> "$PGDATA/postgresql.conf" <<EOF
+# Begin ManageIQ configuration overrides:
+include_dir '${POSTGRESQL_CONFIG_DIR}'
+EOF
+  else
+    echo "${POSTGRESQL_CONFIG_DIR} directory not found, skipping config overrides.."
+  fi
+}
+
 set_pgdata
 check_env_vars
 generate_passwd_file
@@ -28,6 +41,7 @@ if [ "${NEED_TO_CREATE_USERS:-}" == "yes" ]; then
 fi
 set_passwords
 set_miq_role
+include_miq_config
 pg_ctl stop
 
 unset_env_vars


### PR DESCRIPTION
@carbonin @bdunne Please review, I have another PR coming with the corresponding configmaps and corresponding template modifications going to pods. 

- Check for the existance of MIQ PG overrides directory, if available, include it in postgresql.conf
- Defaults taken from https://github.com/ManageIQ/manageiq-appliance/blob/master/COPY/etc/manageiq/postgresql.conf.d/01_miq_overrides.conf
- We use include_dir , so more configs can be stacked, PG will process *.conf in a given dir
- POSTGRESQL_CONFIG_DIR is set via environment variable and can be customized at users convenience
- Can be backported to euwe/CF4.5 builds to allow functionality to existing users, all existing deployments are running almost default settings.
- Resolves #1 

We stack after the default customs from SCL, this is how it looks on config : 
```
bash-4.2$ tail -4 /var/lib/pgsql/data/userdata/postgresql.conf 
# Custom OpenShift configuration:
include '/var/lib/pgsql/openshift-custom-postgresql.conf'
# Begin ManageIQ configuration overrides:
include_dir '/etc/manageiq/postgresql.conf.d'
```
