### PR TITLE
Allow MIQ database backup and restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 # Include config PG dir
 ARG PG_CONF_DIR=/var/lib/pgsql/conf.d
 
+# Add scripts path
+ENV CONTAINER_SCRIPTS_ROOT=/opt/manageiq/container-scripts
+
 # Switch USER to root to add required repo and packages
 USER root
 
@@ -23,6 +26,7 @@ LABEL io.openshift.tags="database,postgresql,postgresql95,rh-postgresql95,pglogi
 
 # Modified pg startup script to add required role
 COPY docker-assets/run-postgresql /usr/bin
+ADD  docker-assets/container-scripts ${CONTAINER_SCRIPTS_ROOT}
 
 # Loosen permission bits to avoid problems running container with arbitrary UID
 RUN mkdir ${PG_CONF_DIR} && \

--- a/docker-assets/container-scripts/backup_db
+++ b/docker-assets/container-scripts/backup_db
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Define vars
+PV_BACKUP_DIR=${PV_BACKUP_DIR:-/backups}
+BACKUP_TIMESTAMP=$(date +%Y%m%dT%H%M%S)
+
+# Sanity checks
+[[ -z ${DATABASE_URL} ]] && echo "ERROR: DATABASE_URL is not defined, exiting.." && exit 1
+
+# PG connstring does not like extra settings
+SHORT_DB_URL=$(echo $DATABASE_URL | cut -d / -f1-3)
+
+echo "== Starting MIQ DB backup =="
+echo "Current time is : $(date)"
+pg_basebackup -x -d ${SHORT_DB_URL} -Ft -z -D ${PV_BACKUP_DIR}/miq_backup_${BACKUP_TIMESTAMP} -P -v
+
+[[ $? -ne 0 ]] && echo "ERROR: ${PG_BASEBACKUP} exited with abnormal status, please check backup status" && exit 1
+
+echo "Sucessfully finished backup : $(date)"
+echo "Backup stored at : ${PV_BACKUP_DIR}/miq_backup_${BACKUP_TIMESTAMP}"
+
+# Set latest symlink to latest successful backup
+
+[[ -h ${PV_BACKUP_DIR}/latest ]] && rm -f ${PV_BACKUP_DIR}/latest
+cd ${PV_BACKUP_DIR} && ln -s miq_backup_${BACKUP_TIMESTAMP} latest

--- a/docker-assets/container-scripts/restore_db
+++ b/docker-assets/container-scripts/restore_db
@@ -43,7 +43,14 @@ echo "Current time is : $(date)"
 mkdir ${PV_RESTORE_DATADIR}
 tar -xzf ${PV_BACKUP_DATADIR}/base.tar.gz -C ${PV_RESTORE_DATADIR} --checkpoint=500
 
-[[ $? -ne 0 ]] && echo "ERROR: DB restore exited with abnormal status, please check job logs" && exit 1
+# Remove failed restore attempt if a failure is detected, restore previous data if it was present
 
-chmod 700 ${PV_RESTORE_DATADIR}
-echo "Sucessfully finished DB restore : $(date)"
+if [[ $? -ne 0 ]]; then 
+  echo "ERROR: DB restore exited with abnormal status, please check job logs"
+  rm -rf ${PV_RESTORE_DATADIR}
+  [[ -d ${PV_RESTORE_DIR}/userdata_${TIMESTAMP} ]] && mv ${PV_RESTORE_DIR}/userdata_${TIMESTAMP} ${PV_RESTORE_DATADIR}
+  exit 1
+else
+  chmod 700 ${PV_RESTORE_DATADIR}
+  echo "Sucessfully finished DB restore : $(date)"
+fi

--- a/docker-assets/container-scripts/restore_db
+++ b/docker-assets/container-scripts/restore_db
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Defaults
+# Notes : 
+# userdata is a directory created by the PG SCL image when the DB is first initialized on pod
+# latest is a symlink created by the backup jobscript pointing to the latest successful backup directory
+
+BACKUP_VERSION=${BACKUP_VERSION:-latest}
+PG_SVC_NAME=${PG_SVC_NAME:-postgresql}
+PV_BACKUP_DIR=${PV_BACKUP_DIR:-/backups}
+PV_BACKUP_DATADIR="${PV_BACKUP_DIR}/${BACKUP_VERSION}"
+PV_RESTORE_DIR=${PV_RESTORE_DIR:-/restore}
+PV_RESTORE_DATADIR="${PV_RESTORE_DIR}/userdata"
+TIMESTAMP=$(date +%Y%m%dT%H%M%S)
+
+# Check if DB service is online, exit if true
+
+echo "== Checking ${PG_SVC_NAME} status =="
+pg_isready -h ${PG_SVC_NAME}
+
+[ "$?" -eq "0" ] && echo "ERROR: PG service MUST BE OFFLINE before a database restore is attempted, exiting.." && exit 1
+
+# Check backup source and destination volumes, also ensure dest is writable
+
+[[ ! -d ${PV_BACKUP_DATADIR} ]] && echo "ERROR: Could not access ${PV_BACKUP_DATADIR}, please check volumes, exiting.." && exit 1
+[[ ! -d ${PV_RESTORE_DIR} ]] && echo "ERROR: Could not access ${PV_RESTORE_DIR}, please check volumes, exiting.." && exit 1
+[[ ! -w ${PV_RESTORE_DIR} ]] && echo "ERROR: ${PV_RESTORE_DIR} is not writable, please check volumes, exiting.." && exit 1
+
+# Check destination for existing data, if data is found rename dir
+
+echo "== Checking for existing PG data =="
+if [[ -d ${PV_RESTORE_DATADIR} ]]; then
+  echo "Existing data found at : ${PV_RESTORE_DATADIR}"
+  mv ${PV_RESTORE_DATADIR} ${PV_RESTORE_DIR}/userdata_${TIMESTAMP}
+  echo "Existing data moved to : ${PV_RESTORE_DIR}/userdata_${TIMESTAMP}"
+else
+  echo "No existing PGDATA dir was found at : ${PV_RESTORE_DATADIR}"
+fi
+
+echo "== Starting MIQ DB restore =="
+echo "Current time is : $(date)"
+
+mkdir ${PV_RESTORE_DATADIR}
+tar -xzf ${PV_BACKUP_DATADIR}/base.tar.gz -C ${PV_RESTORE_DATADIR} --checkpoint=500
+
+[[ $? -ne 0 ]] && echo "ERROR: DB restore exited with abnormal status, please check job logs" && exit 1
+
+chmod 700 ${PV_RESTORE_DATADIR}
+echo "Sucessfully finished DB restore : $(date)"


### PR DESCRIPTION
@carbonin @bdunne 

- Procedure based on https://bugzilla.redhat.com/show_bug.cgi?id=1459652
- Modified Dockerfile to add scripts path at known location
- Scripts are designed to be run stand-alone using an openshift job object
- DB backup script is based on pg_basebackup, making a full binary backup of the entire DB cluster
- DB restore uses tar to decompress backups at the SCL image DATA location