### PR TITLE
Use --xlog-method=stream for pg_basebackup

### DIFF
--- a/container-assets/container-scripts/backup_db
+++ b/container-assets/container-scripts/backup_db
@@ -12,7 +12,7 @@ SHORT_DB_URL=$(echo $DATABASE_URL | cut -d / -f1-3)
 
 echo "== Starting MIQ DB backup =="
 echo "Current time is : $(date)"
-pg_basebackup -x -d ${SHORT_DB_URL} -Ft -z -D ${PV_BACKUP_DIR}/miq_backup_${BACKUP_TIMESTAMP} -P -v
+pg_basebackup --xlog-method=stream -d ${SHORT_DB_URL} -Ft -z -D ${PV_BACKUP_DIR}/miq_backup_${BACKUP_TIMESTAMP} -P -v
 
 [[ $? -ne 0 ]] && echo "ERROR: ${PG_BASEBACKUP} exited with abnormal status, please check backup status" && exit 1
 


### PR DESCRIPTION
Previously we were using the "fetch" method which would fail if
we did not set wal_keep_segments to a high enough value. We were
never setting a value for wal_keep_segments so this would (infrequently)
fail.

https://bugzilla.redhat.com/show_bug.cgi?id=1616022