### PR TITLE
Update image to postgres 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# This image is layered from SCL centos7 openshift postgresql 9.5
-# https://github.com/sclorg/postgresql-container/tree/master/9.5
-FROM centos/postgresql-95-centos7:9.5
+FROM centos/postgresql-10-centos7:latest
 
 MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 
@@ -9,17 +7,6 @@ ENV CONTAINER_SCRIPTS_ROOT=/opt/manageiq/container-scripts/ \
 
 # Switch USER to root to add required repo and packages
 USER root
-
-# Fetch MIQ repo for pglogical and repmgr packages
-RUN curl -sSLko /etc/yum.repos.d/manageiq-ManageIQ-Master-epel-7.repo \
-      https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Master/repo/epel-7/manageiq-ManageIQ-Master-epel-7.repo
- 
-RUN yum -y --setopt=tsflags=nodocs install rh-postgresql95-postgresql-pglogical \
-                                           rh-postgresql95-repmgr && \
-    yum clean all
-
-# Add pglogical openshift tag to new image
-LABEL io.openshift.tags="database,postgresql,postgresql95,rh-postgresql95,pglogical"
 
 ADD container-assets/container-scripts ${CONTAINER_SCRIPTS_ROOT}
 ADD container-assets/on-start.sh ${START_HOOKS_DIR}


### PR DESCRIPTION
This is needed because the image takes care of making the current user a superuser which we need to manage logical replication.

Additionally this image contains scripts for backup and restore that we will continue to use.