### PR TITLE
Update tzdata before reinstall.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN ARCH=$(uname -m) && \
     INSTALL_PKGS="$INSTALL_PKGS pgaudit" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    yum -y update tzdata && \
     yum -y reinstall tzdata && \
     yum -y clean all --enablerepo='*' && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \


### PR DESCRIPTION
I'm not sure why tzdata is reinstalled (copied from sclorg), but if the original package is not available it will fail, updating first ensures that the package is available.

Error:
Installed package tzdata-2022d-1.el9_0.noarch not available.
Error: No packages marked for reinstall.