### PR TITLE
[10-el8] Upgrade to 10.23 from CentOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,21 @@ COPY --from=postgresql_container_source /postgresql-container/10/root/usr/libexe
 # This image must forever use UID 26 for postgres user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y --setopt=tsflags=nodocs install \
-      https://rpm.manageiq.org/release/16-petrosian/el8/noarch/manageiq-release-16.0-1.el8.noarch.rpm && \
-    INSTALL_PKGS="postgresql-server postgresql-contrib rsync tar gettext bind-utils nss_wrapper" && \
+RUN if [ "$(uname -m)" != "s390x" ]; then \
+      yum -y --setopt=tsflags=nodocs install \
+         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
+         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm && \
+      yum -y module enable postgresql:10 && \
+      yum -y --setopt=tsflags=nodocs install postgresql-server postgresql-contrib && \
+      rpm -V postgresql-server postgresql-contrib; \
+    else \
+      yum -y install \
+         /opt/app-root/src/bin-rpm-dir/postgresql-10*.el8.s390x.rpm \
+         /opt/app-root/src/bin-rpm-dir/postgresql-contrib-10*.el8.s390x.rpm \
+         /opt/app-root/src/bin-rpm-dir/postgresql-server-10*.el8.s390x.rpm && \
+      rm -rf /opt/app-root/src/bin-rpm-dir; \
+    fi && \
+    INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y update tzdata && \
@@ -118,6 +130,9 @@ LABEL name="PostgreSQL" \
 
 # Switch USER to root to add required repo and packages
 USER root
+
+RUN yum -y update postgresql-* && \
+    yum clean all
 
 ADD container-assets/container-scripts /opt/manageiq/container-scripts/
 ADD container-assets/on-start.sh ${APP_DATA}/src/postgresql-start/


### PR DESCRIPTION
This reverts commit f09d47adec282ad1feab01421965945ab22920c7, reversing changes made to 05d5da8702784c061b7e48c274e9e2adf08be3b3.

Also fixes:
```
No match for argument: bind-utils
No match for argument: nss_wrapper
Error: Unable to find a match: bind-utils nss_wrapper
Error: error building at STEP "RUN yum -y --setopt=tsflags=nodocs install       https://rpm.manageiq.org/release/16-petrosian/el8/noarch/manageiq-release-16.0-1.el8.noarch.rpm &&     INSTALL_PKGS="postgresql-server postgresql-contrib rsync tar gettext bind-utils nss_wrapper" &&     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS &&     rpm -V $INSTALL_PKGS &&     yum -y update tzdata &&     yum -y reinstall tzdata &&     yum -y clean all --enablerepo='*' &&     localedef -f UTF-8 -i en_US en_US.UTF-8 &&     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" &&     mkdir -p /var/lib/pgsql/data &&     /usr/libexec/fix-permissions /var/lib/pgsql /var/run/postgresql": error while running runtime: exit status 1
```