### PR TITLE
[10-el8] Centos stream 8 eol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,8 @@ COPY --from=postgresql_container_source /postgresql-container/10/root/usr/libexe
 # to make sure of that.
 RUN if [ "$(uname -m)" != "s390x" ]; then \
       yum -y --setopt=tsflags=nodocs install \
-         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
-         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm; \
+        https://rpm.manageiq.org/builds/centos/centos-stream-repos-8-6.1.el8.noarch.rpm \
+        https://rpm.manageiq.org/builds/centos/centos-gpg-keys-8-6.1.el8.noarch.rpm; \
     fi && \
     yum -y module enable postgresql:10 && \
     INSTALL_PKGS="postgresql-server postgresql-contrib rsync tar gettext bind-utils nss_wrapper" && \


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq-rpm_build/pull/467

Unfortunately the repos RPM in the vault still points to mirrors.centos.org which is no longer serving Stream 8. I patched the RPMs and posted them on rpm.manageiq.org with a change to point all repos to the vault.
