### PR TITLE
[10-el8] Lock down to the commit before the postgres 10 directory deletion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN cd /tmp && \
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS postgresql_container_source
 
 RUN microdnf -y --setopt=tsflags=nodocs install git
-RUN git clone --depth 1 https://github.com/sclorg/postgresql-container /postgresql-container
+RUN git clone https://github.com/sclorg/postgresql-container /postgresql-container && \
+    cd /postgresql-container && \
+    git checkout b455357a2e281bb224c547dbf948cc8745937181
 
 ################################################################################
 


### PR DESCRIPTION
Failure:
```
[3/4] STEP 7/15: COPY --from=postgresql_container_source /postgresql-container/10/root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
Error: building at STEP "COPY --from=postgresql_container_source /postgresql-container/10/root/usr/libexec/fix-permissions /usr/libexec/fix-permissions": checking on sources under ".../.local/share/containers/storage/overlay/5fa06dc984848b72edaa03d05a40be2173a62049c6bb9bb4133740f74271cbbe/merged": copier: stat: "/postgresql-container/10/root/usr/libexec/fix-permissions": no such file or directory
```