### PR TITLE
[13-el9] /var/run/postgresql was removed from postgresql-server-13.16-1 RPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,8 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs update &
     chmod -R g+w /etc/pki/tls && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     mkdir -p /var/lib/pgsql/data && \
-    /usr/libexec/fix-permissions /var/lib/pgsql /var/run/postgresql
+    mkdir -p /run/postgresql && \
+    /usr/libexec/fix-permissions /var/lib/pgsql /run/postgresql
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \


### PR DESCRIPTION
Related:
- https://github.com/sclorg/postgresql-container/pull/588
- https://gitlab.com/redhat/centos-stream/rpms/postgresql/-/commit/ced30efb935315a3ac323a526671010d6a50f1d7 

ERROR:
```
  pkgconf-pkg-config-1.7.3-10.el9.x86_64
  postgresql-13.16-1.el9.x86_64
  postgresql-contrib-13.16-1.el9.x86_64
  postgresql-private-libs-13.16-1.el9_4.x86_64
  postgresql-server-13.16-1.el9.x86_64
  protobuf-c-1.3.3-13.el9.x86_64
  setup-2.13.7-10.el9.noarch
  shadow-utils-2:4.9-9.el9.x86_64
  uuid-1.6.2-55.el9.x86_64

Complete!
Found VERSION 13
Last metadata expiration check: 0:00:12 ago on Mon Oct 28 15:14:16 2024. Dependencies resolved.
================================================================================
 Package       Architecture  Version             Repository                Size
================================================================================
Reinstalling:
 tzdata        noarch        2024a-1.el9         ubi-9-baseos-rpms        842 k

Transaction Summary
================================================================================

Total download size: 842 k
Installed size: 1.6 M
Downloading Packages:
tzdata-2024a-1.el9.noarch.rpm                   5.1 MB/s | 842 kB     00:00
--------------------------------------------------------------------------------
Total                                           5.0 MB/s | 842 kB     00:00
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1
  Reinstalling     : tzdata-2024a-1.el9.noarch                              1/2
  Cleanup          : tzdata-2024a-1.el9.noarch                              2/2
  Verifying        : tzdata-2024a-1.el9.noarch                              1/2
  Verifying        : tzdata-2024a-1.el9.noarch                              2/2

Reinstalled:
  tzdata-2024a-1.el9.noarch

Complete!
47 files removed
fixing permissions on '/var/lib/pgsql' directory
/usr/libexec/fix-permissions: Error: no such directory '/var/run/postgresql'

Usage: /usr/libexec/fix-permissions [--read-only] DIR [DIR ..]

Recursively fix permissions on the given directories to allow GID=0 read/write regular files and read/write/execute directories.

To run this command, you have to be in the group root=0!
Error: building at STEP "RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs update &&     (dnf info postgresql-server);     if [ $? == 1 ]; then       ARCH=$(uname -m) &&       dnf -y --setopt=protected_packages= remove redhat-release &&       dnf -y remove *subscription-manager* &&       dnf -y install         http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-release-9.0-24.el9.noarch.rpm         http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-24.el9.noarch.rpm         http://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-24.el9.noarch.rpm &&       dnf clean all &&       rm -rf /var/cache/dnf;     fi &&     { yum -y module enable postgresql:13 || :; } &&     INSTALL_PKGS="rsync tar gettext bind-utils nss_wrapper postgresql-server postgresql-contrib" &&     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS &&     rpm -V $INSTALL_PKGS &&     postgres -V | grep -qe "$POSTGRESQL_VERSION\." && echo "Found VERSION $POSTGRESQL_VERSION" &&     (yum -y reinstall tzdata || yum -y update tzdata ) &&     yum -y clean all --enablerepo='*' &&     localedef -f UTF-8 -i en_US en_US.UTF-8 &&     chmod -R g+w /etc/pki/tls &&     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" &&     mkdir -p /var/lib/pgsql/data &&     /usr/libexec/fix-permissions /var/lib/pgsql /var/run/postgresql": while running runtime: exit status 1
```
