### PR TITLE
Temporarily lock down to 10.2 due to signature issues on s390x latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS manifest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2 AS manifest
 
 COPY .git /tmp/.git
 
@@ -9,7 +9,7 @@ RUN cd /tmp && \
 
 ################################################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS postgresql_container_source
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2 AS postgresql_container_source
 
 RUN microdnf -y --setopt=tsflags=nodocs install git
 RUN git clone --depth 1 https://github.com/sclorg/postgresql-container /postgresql-container


### PR DESCRIPTION
```
podman pull --platform linux/s390x registry.access.redhat.com/ubi10/ubi-minimal:latest 
Trying to pull registry.access.redhat.com/ubi10/ubi-minimal:latest... 
Error: unable to copy from source docker://registry.access.redhat.com/ubi10/ubi-minimal:latest: copying system image from manifest list: Source image rejected: None of the signatures were accepted, reasons: missing dev.sigstore.cosign/bundle annotation; missing dev.sigstore.cosign/bundle annotation; Signature for identity "registry.redhat.io/ubi10/ubi-minimal:10.2-1779862102" is not accepted; Signature for identity "registry.redhat.io/ubi10/ubi-minimal:latest" is not accepted; Signature for identity "registry.access.redhat.com/ubi10/ubi-minimal:10.2" is not accepted; Signature for identity "registry.access.redhat.com/ubi10/ubi-minimal:10.2-1779862102" is not accepted
```

https://github.com/ManageIQ/manageiq/issues/23855
