### PR TITLE
Revert "Temporarily lock down to 10.2 due to signature issues on s390x latest"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2 AS manifest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS manifest
 
 COPY .git /tmp/.git
 
@@ -9,7 +9,7 @@ RUN cd /tmp && \
 
 ################################################################################
 
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2 AS postgresql_container_source
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS postgresql_container_source
 
 RUN microdnf -y --setopt=tsflags=nodocs install git
 RUN git clone --depth 1 https://github.com/sclorg/postgresql-container /postgresql-container


### PR DESCRIPTION
This reverts commit db12869fe8e1a19854d7faddc2c468ecbe99e6ae.

A new UBI was published and the signatures are now valid.
https://github.com/ManageIQ/manageiq/issues/23855